### PR TITLE
Named arguments & tslint (#6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "@types/moment-timezone": "^0.5.4",
         "chai": "^4.1.2",
         "mocha": "^5.2.0",
+        "tslint": "^5.11.0",
         "typescript": "^2.9.2"
     }
 }

--- a/src/structures/subtag.errors.ts
+++ b/src/structures/subtag.errors.ts
@@ -9,6 +9,7 @@ export function custom(code: string, message: string): SubTagError {
 
 export const system = {
     missingSubtag() { return custom('BB-S-MS', `Missing subtag name`); },
+    missingKeyValueKey() { return custom('BB-S-MK', `Missing key in key-value pair`); },
     unknownSubtag(name: string) { return custom('BB-S-US', `Unknown subtag '${name || '\u200b'}'`); },
     internalError() { return custom('BB-S-IS', `An internal server error has occurred`); }
 }
@@ -16,7 +17,9 @@ export const system = {
 export const args = {
     notEnough(minimum: number) { return custom('BB-A-NE', `Not enough arguments. Minimum ${minimum}`); },
     tooMany(maximum: number) { return custom('BB-A-TM', `Too many arguments. Maximum ${maximum}`); },
-    outOfRange() { return custom('BB-A-OR', `Arguments out of range`); }
+    outOfRange() { return custom('BB-A-OR', `Arguments out of range`); },
+    nonNamed() { return custom('BB-A-NN', 'Named and positional arguments cannot be mixed'); },
+    unknownNamed(name: string) { return custom('BB-A-UN', `Unknown named arg ${name}`); }
 }
 
 export const value = {
@@ -30,6 +33,7 @@ export const value = {
     notANumber(text: string) { return custom('BB-V-NU', `'${text}' is not a number`); },
     notAnArray(text: string) { return custom('BB-V-AR', `'${text}' is not an array`); },
     notABool(text: string) { return custom('BB-V-TF', `'${text}' is not a boolean`); },
+    notAnOperator(value: string) { return custom('BB-V-NO', `'${value}' is not a valid operator`); },
     notAComparer(values: string[]) {
         return custom('BB-V-CM', `${
             smartJoin(values, ', ', ' and ')

--- a/src/structures/subtag.map.ts
+++ b/src/structures/subtag.map.ts
@@ -1,8 +1,10 @@
 import { SubTag } from './subtag';
+import { subtags } from '../subtags/general/system';
 
 export class SubTagMap {
     private readonly _members: Set<SubTag<any>> = new Set();
     private readonly _map: { [key: string]: SubTag<any> } = {};
+    private readonly _whenAdded: Map<any, Array<(subtag: SubTag<any>) => void>> = new Map();
 
     public get members(): ReadonlyArray<SubTag<any>> { return Array.from(this._members) };
 
@@ -20,6 +22,20 @@ export class SubTagMap {
     }
 
     public add(subtag: SubTag<any>): this {
+        this._add(subtag);
+
+        let waiting = this._whenAdded.get(Object.getPrototypeOf(subtag));
+
+        if (waiting !== undefined) {
+            for (const handler of waiting) {
+                handler(subtag);
+            }
+        }
+
+        return this;
+    }
+
+    private _add(subtag: SubTag<any>): this {
         for (const name of this.getNames(subtag)) {
             if (name in this._map) {
                 throw new Error(`Subtag name ${name} already exists. Currently belongs to ${this._map[name].name}`);
@@ -33,6 +49,10 @@ export class SubTagMap {
     }
 
     public remove(subtag: SubTag<any>): this {
+        return this._remove(subtag);
+    }
+
+    private _remove(subtag: SubTag<any>): this {
         for (const name of this.getNames(subtag)) {
             if (name in this._map && this._map[name] == subtag) {
                 delete this._map[name];
@@ -44,10 +64,29 @@ export class SubTagMap {
         return this;
     }
 
+    public reload(subtag: SubTag<any>): this {
+        if (this._members.has(subtag))
+            this._remove(subtag)._add(subtag);
+
+        return this;
+    }
+
     public get(name: string): SubTag<any> | undefined {
         name = name.toLowerCase();
         if (name in this._map) {
             return this._map[name];
+        }
+    }
+
+    public onceAdded(subtag: typeof SubTag, handler: (subtag: SubTag<any>) => void) {
+        let existing = this.members.find(member => Object.getPrototypeOf(member) === subtag.prototype);
+        if (existing !== undefined) {
+            handler(existing);
+        } else {
+            let current = this._whenAdded.get(subtag.prototype);
+            if (current === undefined)
+                this._whenAdded.set(subtag.prototype, current = []);
+            current.push(handler);
         }
     }
 }

--- a/src/structures/subtag.ts
+++ b/src/structures/subtag.ts
@@ -1,10 +1,11 @@
-import { BBString, BBSubTag } from '../language';
+import { BBString, BBSubTag, BBSource } from '../language';
 import { Context } from './context';
 import { Engine } from '../engine';
 import { Condition } from './subtag.conditions';
 import * as conditions from './subtag.conditions';
 import * as errors from './subtag.errors';
 import { IDatabase } from '../interfaces/idatabase';
+import { array } from '../util';
 
 function ensureArray(value?: string | string[]): string[] {
     if (Array.isArray(value))
@@ -32,6 +33,12 @@ export abstract class SubTag<TContext extends Context> {
     public readonly errors = SubTag.errors;
     public readonly conditions = SubTag.conditions;
 
+    private maxArgs: number = 0;
+    private minArgs: number = 0;
+    private remainingArgMap: { important: number, required: number }[] = [];
+
+    protected namedArgs: NamedArgument[] = [];
+
     protected constructor(engine: Engine, name: string, options: BaseSubtagOptions<TContext>) {
         this.context = options.context;
         this.engine = engine;
@@ -43,8 +50,57 @@ export abstract class SubTag<TContext extends Context> {
         this.globalNames = ensureArray(options.globalName);
     }
 
+    protected setNamedArgs(namedArgs: NamedArgument[]) {
+        let important = 0;
+        let required = 0;
+
+        // Check there are no duplicated key names
+        let keyMap: string[] = [];
+        let duplicatedKeys = namedArgs.filter(arg => {
+            if (keyMap.indexOf(arg.key.toLowerCase()) === -1) {
+                keyMap.push(arg.key.toLowerCase());
+                return false;
+            }
+            return true;
+        });
+        if (duplicatedKeys.length > 0) {
+            throw new DuplicatedArgumentKeys(this, duplicatedKeys);
+        }
+
+        // Reset the argument variables
+        this.namedArgs = namedArgs;
+        this.maxArgs = this.minArgs = 0;
+        this.remainingArgMap = [];
+
+        // Loop through the named args backwards. 
+        // For each element increase the max & min args where needed
+        // and increase the important/required counts where needed.
+        // important & required are a count of the number of such args
+        // after the current element, hence the reverse loop
+        for (let i = namedArgs.length - 1; i >= 0; i--) {
+            this.remainingArgMap.splice(0, 0, { important, required });
+            let arg = namedArgs[i];
+            if (arg.optional) {
+                this.maxArgs++;
+                if (arg.priority) {
+                    important++;
+                }
+            } else {
+                this.minArgs++;
+                this.maxArgs++;
+                important++;
+                required++;
+            }
+        }
+    }
+
     protected whenArgs(condition: Condition, handler: SubTagHandler<TContext>): this {
         this.rules.push({ condition: condition.bind(this), handler: handler.bind(this) });
+        return this;
+    }
+
+    protected default(handler: SubTagHandler<TContext>): this {
+        this.rules.push({ condition: () => true, handler: handler.bind(this) });
         return this;
     }
 
@@ -64,18 +120,150 @@ export abstract class SubTag<TContext extends Context> {
         return await Promise.all(promises);
     }
 
-    public async execute(subtag: BBSubTag, context: TContext): Promise<string> {
-        let handler: SubTagHandler<TContext> | undefined;
-        for (const rule of this.rules) {
-            if (await rule.condition(subtag)) {
-                handler = rule.handler.bind(this);
-                break;
+    protected async parseNamedArg(subtag: BBSubTag, context: TContext, rawArgs: RawArguments, name: string, ) {
+        let result = await this.parseNamedArgs(subtag, context, rawArgs, name);
+        return result.args[name];
+    }
+
+    protected async parseNamedArgs(subtag: BBSubTag, context: TContext, rawArgs: RawArguments, names?: string | string[]) {
+        let args: { [name: string]: string | string[] } = {};
+
+        if (names === undefined) {
+            names = this.namedArgs.map(a => a.key);
+        } else if (!Array.isArray(names)) {
+            names = [names];
+        }
+
+        for (const key in rawArgs) {
+            if (names.indexOf(key) > -1) {
+                let arg = rawArgs[key];
+                if (Array.isArray(arg)) {
+                    let arr = [];
+                    for (const p of arg)
+                        arr.push(await this.engine.execute(p, context));
+                    args[key] = arr;
+                } else {
+                    args[key] = await this.engine.execute(arg, context);
+                }
             }
         }
-        if (handler === undefined)
-            throw new MissingHandlerError(this, subtag);
 
-        let result = await handler(subtag, context);
+        return { raw: rawArgs, args };
+    }
+
+    private async mapNamedArgs(subtag: BBSubTag, context: TContext) {
+        let rawArgs: RawArguments = {};
+        if (subtag.named) { // map named args
+            for (const part of subtag.args[0].parts) {
+                if (typeof part !== 'string') {
+                    if (part.keyValue && part.name) {
+                        let key = await this.engine.execute(part.name, context);
+                        key = key.substring(1); // remove * prefix
+                        let arg = this.namedArgs.find(na => na.key === key);
+                        if (arg) {
+                            if (arg.repeated) {
+                                let entry = rawArgs[key];
+                                let argArray = Array.isArray(entry) ? entry : entry = rawArgs[key] = [];
+                                argArray.push(part.args[0]);
+                            } else {
+                                rawArgs[key] = part.args[0];
+                            }
+                        } else {
+                            return this.errors.args.unknownNamed(key);
+                        }
+                    } else {
+                        return this.errors.args.nonNamed();
+                    }
+                }
+            }
+        } else { // map positional args
+            let current = 0;
+            let conditionals: { key: string, requires: string, value: BBString }[] = [];
+            function handleConditions() {
+                let met = array.all(conditionals, c =>
+                    array.any(conditionals, e => c.requires === e.key)
+                );
+                if (met) {
+                    for (const condition of conditionals) {
+                        rawArgs[condition.key] = condition.value;
+                    }
+                } else {
+                    current -= conditionals.length;
+                }
+                conditionals = [];
+            }
+            for (let i = 0; i < this.namedArgs.length; i++) {
+                let arg = this.namedArgs[i];
+                let remaining = this.remainingArgMap[i];
+                if (!arg.conditional && conditionals.length > 0) {
+                    handleConditions();
+                }
+                let remainingParts = subtag.args.length - current;
+                let part = subtag.args[current];
+
+                if (arg.repeated) {
+                    let repeatCount = current + Math.max(arg.optional ? 0 : 1, remainingParts - remaining.required);
+                    let values = subtag.args.slice(current, repeatCount);
+                    if (values.length > 0) {
+                        rawArgs[arg.key] = values;
+                        current += values.length;
+                    }
+                } else {
+                    if (!arg.optional) {
+                        if (!part) {
+                            return this.errors.args.notEnough(this.minArgs);
+                        }
+                        rawArgs[arg.key] = part;
+                        current++;
+                    } else {
+                        if (remainingParts > remaining.required) {
+                            if (arg.conditional) {
+                                conditionals.push({ key: arg.key, requires: arg.conditional, value: part });
+                                current++;
+                            } else if (arg.priority || remainingParts > remaining.important) {
+                                rawArgs[arg.key] = part;
+                                current++;
+                            }
+                        } else {
+                            continue;
+                        }
+                    }
+                }
+            }
+            if (conditionals.length > 0) {
+                handleConditions();
+            }
+            if (subtag.args.length > current) {
+                return this.errors.args.tooMany(this.maxArgs);
+            }
+        }
+        return rawArgs;
+    }
+
+    public async execute(subtag: BBSubTag, context: TContext): Promise<string> {
+        let args: RawArguments | SubTagError = {};
+        if (this.namedArgs.length > 0)
+            args = await this.mapNamedArgs(subtag, context);
+
+        let handler: SubTagHandler<TContext> | undefined;
+
+        let result: any;
+
+        if (typeof args === 'function') {
+            result = await args(subtag, context);
+        } else {
+            for (const rule of this.rules) {
+                if (await rule.condition(subtag, args)) {
+                    handler = rule.handler.bind(this);
+                    break;
+                }
+            }
+
+            if (handler === undefined)
+                throw new MissingHandlerError(this, subtag);
+
+            result = await handler(subtag, context, args);
+        }
         switch (typeof result) {
             case 'function': return await (<SubTagError>result)(subtag, context);
             case 'string': return <string>result;
@@ -95,24 +283,47 @@ export abstract class SystemSubTag extends SubTag<Context> {
     }
 }
 
+export class DuplicatedArgumentKeys<TContext extends Context> extends Error {
+    public keys: NamedArgument[];
+    public subtag: SubTag<TContext>;
+
+    constructor(subtag: SubTag<TContext>, keys: NamedArgument[]) {
+        super(`Duplicated argument keys ${keys.map(arg => arg.key)} on ${subtag.name}`);
+        this.subtag = subtag;
+        this.keys = keys;
+    }
+}
+
 export class MissingHandlerError<TContext extends Context> extends Error {
     public subtag: SubTag<TContext>;
     public part: BBSubTag;
 
     constructor(subtag: SubTag<TContext>, part: BBSubTag) {
-        super(`Missing handler on ${subtag.name} for ${JSON.stringify(part.args)}`);
+        super(`Missing handler on ${subtag.name}`);
         this.subtag = subtag;
         this.part = part;
     }
 }
 
 export type BaseSubtagOptions<TContext> = SubTagOptions & { context: new (...args: any[]) => TContext };
-export type SubTagHandler<TContext> = (subtag: BBSubTag, context: TContext) => SubTagResult;
+export type SubTagHandler<TContext> = (subtag: BBSubTag, context: TContext, args: RawArguments) => SubTagResult;
 export type SubTagRule<TContext> = { condition: Condition, handler: SubTagHandler<TContext> };
 export type SubTagError = (part: BBString | BBSubTag, context: Context) => Promise<string>;
 export type SubTagResult = Promise<void | string | boolean | number | Array<string | number> | SubTagError>;
 export interface SubTagOptions {
-    alias?: string | string[],
-    category?: string,
-    globalName?: string | string[]
+    alias?: string | string[];
+    category?: string;
+    globalName?: string | string[];
+    allowNamed?: boolean;
+}
+export interface NamedArgument {
+    key: string;
+    desc?: string;
+    optional?: boolean;
+    repeated?: boolean;
+    conditional?: string;
+    priority?: boolean;
+}
+export interface RawArguments {
+    [name: string]: BBString | BBString[];
 }

--- a/src/subtags/general/math/floor.ts
+++ b/src/subtags/general/math/floor.ts
@@ -1,4 +1,5 @@
-import { Engine, hasCount, BBSubTag, Context, SystemSubTag, SubTagError } from '../util';
+import { Engine, hasCount, hasArgs, BBSubTag, Context, SystemSubTag, SubTagError } from '../util';
+import { RawArguments } from '../../../structures/subtag';
 
 export class Floor extends SystemSubTag {
     constructor(engine: Engine) {
@@ -8,16 +9,18 @@ export class Floor extends SystemSubTag {
             alias: ['rounddown']
         });
 
-        this.whenArgs(hasCount(0), this.errors.args.notEnough(1))
-            .whenArgs(hasCount(1), this.floor)
-            .whenArgs(hasCount('>1'), this.errors.args.tooMany(1));
+        this.setNamedArgs([
+            { key: 'number' }
+        ]);
+
+        this.whenArgs(hasArgs(['number']), this.floor);
     }
 
-    async floor(subtag: BBSubTag, context: Context): Promise<number | SubTagError> {
-        let [value] = await this.parseArgs(subtag, context);
-        let parsed = parseFloat(value);
+    async floor(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<number | SubTagError> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        let parsed = parseFloat(<string>args.number);
         if (isNaN(parsed))
-            return this.errors.value.notANumber(value);
+            return this.errors.value.notANumber(<string>args.number);
         return Math.floor(parsed);
     }
 }

--- a/src/subtags/general/system/bool.ts
+++ b/src/subtags/general/system/bool.ts
@@ -1,32 +1,37 @@
-import { Engine, hasCount, BBSubTag, Context, SystemSubTag, SubTagError, util } from '../util';
+import { Engine, hasCount, hasArgs, BBSubTag, Context, SystemSubTag, SubTagError, util } from '../util';
+import { makeOperatorCollection } from '../../util';
+import { SubTagHandler, SubTag, RawArguments } from '../../../structures/subtag';
+import { Operator } from './operator';
 
-type comparer = (a: string, b: string) => boolean;
+export type comparer = (a: string, b: string) => boolean;
 
 export class Bool extends SystemSubTag {
-    public static readonly operator_definitions = {
-        '==': ((a, b) => util.Comparer.Default.areEqual(a, b)) as comparer,
-        '!=': ((a, b) => util.Comparer.Default.notEqual(a, b)) as comparer,
-        '>': ((a, b) => util.Comparer.Default.greaterThan(a, b)) as comparer,
-        '>=': ((a, b) => util.Comparer.Default.greaterOrEqual(a, b)) as comparer,
-        '<': ((a, b) => util.Comparer.Default.lessThan(a, b)) as comparer,
-        '<=': ((a, b) => util.Comparer.Default.lessOrEqual(a, b)) as comparer,
-        'startswith': ((a, b) => util.Comparer.Default.startsWith(a, b)) as comparer,
-        'endswith': ((a, b) => util.Comparer.Default.endsWith(a, b)) as comparer,
-        'contains': ((a, b) => util.Comparer.Default.includes(a, b)) as comparer,
-    }
+    public static readonly operators = makeOperatorCollection<comparer>(
+        { names: ['==', '=', 'eq'], action: (a, b) => util.Comparer.Default.areEqual(a, b) },
+        { names: ['!=', '!', 'ne'], action: (a, b) => util.Comparer.Default.notEqual(a, b) },
+        { names: ['>', 'gt'], action: (a, b) => util.Comparer.Default.greaterThan(a, b) },
+        { names: ['<', 'lt'], action: (a, b) => util.Comparer.Default.lessThan(a, b) },
+        { names: ['>=', 'ge'], action: (a, b) => util.Comparer.Default.greaterOrEqual(a, b) },
+        { names: ['<=', 'le'], action: (a, b) => util.Comparer.Default.lessOrEqual(a, b) },
+        { names: ['startswith', 'sw'], action: (a, b) => util.Comparer.Default.startsWith(a, b) },
+        { names: ['endswith', 'ew'], action: (a, b) => util.Comparer.Default.endsWith(a, b) },
+        { names: ['includes', 'inc'], action: (a, b) => util.Comparer.Default.includes(a, b) },
+    );
 
-    public static readonly operator_aliases = {
-        '=': Bool.operator_definitions['=='],
-        '!': Bool.operator_definitions['!='],
-        'sw': Bool.operator_definitions['startswith'],
-        'ew': Bool.operator_definitions['endswith'],
-        'inc': Bool.operator_definitions['contains'],
-        'includes': Bool.operator_definitions['contains']
-    }
-
-    public static readonly operators = {
-        ...Bool.operator_definitions,
-        ...Bool.operator_aliases
+    private makeHandler(operator: string): SubTagHandler<Context> {
+        let valid = hasCount('1-2');
+        let notEnough = hasCount('0');
+        let tooMany = hasCount('>2');
+        return async (subtag: BBSubTag, context: Context, rawArgs: RawArguments) => {
+            if (await notEnough(subtag, rawArgs)) {
+                return this.errors.args.notEnough(1);
+            } else if (await valid(subtag, rawArgs)) {
+                let args = await this.parseArgs(subtag, context);
+                return Bool.compare(operator, ...args);
+            } else if (await tooMany(subtag, rawArgs)) {
+                return this.errors.args.tooMany(2);
+            }
+        };
     }
 
     constructor(engine: Engine) {
@@ -35,20 +40,35 @@ export class Bool extends SystemSubTag {
             globalName: ['bool'],
         });
 
-        this.whenArgs(hasCount('<2'), this.errors.args.notEnough(2))
-            .whenArgs(hasCount('2-3'), this.run)
-            .whenArgs(hasCount('>3'), this.errors.args.tooMany(3));
+        this.setNamedArgs([
+            { key: 'a', optional: true },
+            { key: 'operator' },
+            { key: 'b' }
+        ]);
+
+        this.whenArgs(hasArgs(['a', 'operator', 'b']), this.run)
+            .whenArgs(hasArgs(['operator', 'b']), this.run);
+
+        this.engine.subtags.onceAdded(Operator as typeof SubTag, (operator: SubTag<any>) => {
+            for (const key of Object.keys(Bool.operators)) {
+                (operator as Operator).registerOperator(key, this.makeHandler(key));
+            }
+        });
     }
 
-    public async run(subtag: BBSubTag, context: Context): Promise<boolean | SubTagError> {
-        let args = await this.parseArgs(subtag, context);
-        return Bool.compare(...args);
+    public async run(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<boolean | SubTagError> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs, ['a', 'b', 'operator']);
+        let arr: string[] = [];
+        if (args.a) arr.push(<string>args.a);
+        if (args.operator) arr.push(<string>args.operator);
+        if (args.b) arr.push(<string>args.b);
+        return Bool.compare(...arr);
     }
 
     public static getOperator(operator: string): comparer | undefined {
         operator = operator.toLowerCase();
         if (operator in this.operators) {
-            return (<any>this.operators)[operator];
+            return this.operators[operator];
         }
         return undefined;
     }

--- a/src/subtags/general/system/if.ts
+++ b/src/subtags/general/system/if.ts
@@ -1,5 +1,6 @@
-import { Engine, hasCount, BBSubTag, Context, SystemSubTag, SubTagError, util } from '../util';
+import { Engine, hasCount, hasArgs, BBSubTag, Context, SystemSubTag, SubTagError, util } from '../util';
 import { Bool } from './bool';
+import { RawArguments } from '../../../structures/subtag';
 
 export class If extends SystemSubTag {
     constructor(engine: Engine) {
@@ -8,9 +9,18 @@ export class If extends SystemSubTag {
             globalName: ['if']
         });
 
-        this.whenArgs(hasCount('<2'), this.errors.args.notEnough(2))
-            .whenArgs(hasCount('2-5'), this.run)
-            .whenArgs(hasCount('>5'), this.errors.args.tooMany(5));
+        this.setNamedArgs([
+            { key: 'a' },
+            { key: 'operator', optional: true, conditional: 'b' },
+            { key: 'b', optional: true, conditional: 'operator' },
+            { key: 'then' },
+            { key: 'else', optional: true }
+        ]);
+
+        this.whenArgs(hasArgs(['a', 'operator', 'b', 'then', 'else']), this.run)
+            .whenArgs(hasArgs(['a', 'operator', 'b', 'then']), this.run)
+            .whenArgs(hasArgs(['a', 'then', 'else']), this.run)
+            .whenArgs(hasArgs(['a', 'then']), this.run);
     }
 
     private parseBool(text: string): boolean | SubTagError {
@@ -20,27 +30,19 @@ export class If extends SystemSubTag {
         return this.errors.value.notABool(text);
     }
 
-    public async run(subtag: BBSubTag, context: Context): Promise<string | SubTagError> {
-        let success: boolean | SubTagError = false,
-            then: number = -1,
-            otherwise: number = -1;
-        switch (subtag.args.length) {
-            case 3:
-                otherwise = 2;
-            case 2:
-                success = this.parseBool(await this.parseArg(subtag, context, 0));
-                then = 1;
-                break;
-            case 5:
-                otherwise = 4;
-            case 4:
-                success = await Bool.compare(...await this.parseArgs(subtag, context, [0, 1, 2]));
-                then = 3;
+    public async run(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string | SubTagError> {
+        let success: boolean | SubTagError = false;
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs, ['a', 'b', 'operator']);
+
+        if (args.a && args.operator && args.b) {
+            success = await Bool.compare(<string>args.a, <string>args.operator, <string>args.b);
+        } else if (!args.operator && !args.b) {
+            success = this.parseBool(<string>args.a);
         }
 
         if (typeof success === 'function')
             return success;
 
-        return await this.parseArg(subtag, context, success ? then : otherwise) || '';
+        return <string>await this.parseNamedArg(subtag, context, rawArgs, success ? 'then' : 'else') || '';
     }
 }

--- a/src/subtags/general/system/operator.ts
+++ b/src/subtags/general/system/operator.ts
@@ -1,0 +1,37 @@
+import { SystemSubTag, Context, BBSubTag, BBString, Engine } from '../util';
+import { SubTagHandler } from '../../../structures/subtag';
+
+export class Operator extends SystemSubTag {
+    private readonly operators: { [key: string]: SubTagHandler<any> } = {};
+
+    constructor(engine: Engine) {
+        super(engine, 'operator', {
+            category: 'system'
+        });
+
+        this.whenArgs(() => true, this.run);
+        Object.defineProperty(this, 'globalNames', {
+            get: () => { return Object.keys(this.operators); }
+        });
+    }
+
+    public registerOperator(operators: string | string[], handler: SubTagHandler<any>) {
+        if (!Array.isArray(operators))
+            operators = [operators];
+        for (const operator of operators) {
+            this.operators[operator] = handler;
+        }
+
+        this.engine.subtags.reload(this);
+    }
+
+    public async run(subtag: BBSubTag, context: Context) {
+        let operator = subtag.resolvedName.toLowerCase();
+        let handler = this.operators[operator];
+        if (handler != null) {
+            return await handler(subtag, context, {});
+        }
+
+        return this.errors.value.notAnOperator(operator);
+    }
+}

--- a/src/subtags/util.ts
+++ b/src/subtags/util.ts
@@ -7,3 +7,16 @@ export { Context, Permission, RunMode } from '../structures/context';
 export { SystemSubTag, SubTagError, SubTag } from '../structures/subtag';
 export { errors, util };
 export * from '../structures/subtag.conditions';
+
+export function makeOperatorCollection<TAction extends Function>
+    (...definitions: { names: string[], action: TAction }[]): { [key: string]: TAction } {
+    let result = {} as { [key: string]: TAction };
+
+    for (const definition of definitions) {
+        for (const name of definition.names || []) {
+            result[name] = definition.action;
+        }
+    }
+
+    return result;
+}

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -61,3 +61,23 @@ export function deserialize(text: string): BBArray | undefined {
         return { v: parsed.v.map(stringify), n: parsed.n };
     return { v: parsed.v.map(stringify) };
 }
+
+export function all<T>(array: Array<T>, check: (entry: T) => boolean) {
+    for (const entry of array || []) {
+        if (!check(entry)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+export function any<T>(array: Array<T>, check: (entry: T) => boolean) {
+    for (const entry of array || []) {
+        if (check(entry)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/test/conditions.test.ts
+++ b/test/conditions.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { hasCount, hasCounts, BBSubTag } from '../dist';
+import { RawArguments } from '../dist/structures/subtag';
 
 function mockSubTagArgs(args: any[]): BBSubTag {
     return <BBSubTag><any>{ args };
@@ -14,7 +15,7 @@ describe('SubtagConditions', () => {
             for (const entry of cases) {
                 // act
                 let subtag = mockSubTagArgs(entry.args);
-                let result = await check(subtag);
+                let result = await check(subtag, {});
 
                 // assert
                 expect(result).to.be.equal(entry.expect);
@@ -120,7 +121,7 @@ describe('SubtagConditions', () => {
             for (const entry of cases) {
                 // act
                 let subtag = mockSubTagArgs(entry.args);
-                let result = await check(subtag);
+                let result = await check(subtag, {});
 
                 // assert
                 expect(result).to.be.equal(entry.expect);

--- a/test/language.test.ts
+++ b/test/language.test.ts
@@ -183,6 +183,27 @@ describe('Language', () => {
             // act & assert
             expect(language.parse.bind(null, input)).to.throw(language.ParseError, '[1:17]: Unexpected \'}\'');
         });
+        it('should fail when named args are used with normal args', () => {
+            // arrange
+            let input = '{this=is;a;test}';
+
+            // act && assert
+            expect(language.parse.bind(null, input)).to.throw(language.ParseError, '[1:1]: Cannot use \';\' when using named arguments');
+        });
+        it('should fail when key-value pairs have more than 1 arg', () => {
+            // arrange
+            let input = '{*this;is;a;test}';
+
+            // act && assert
+            expect(language.parse.bind(null, input)).to.throw(language.ParseError, '[1:1]: Key-Values must have exactly 1 argument');
+        });
+        it('should fail when key-value pairs have less than 1 arg', () => {
+            // arrange
+            let input = '{*this is a test}';
+
+            // act && assert
+            expect(language.parse.bind(null, input)).to.throw(language.ParseError, '[1:1]: Key-Values must have exactly 1 argument');
+        });
     })
 });
 

--- a/test/mocks/subtags/echo.ts
+++ b/test/mocks/subtags/echo.ts
@@ -6,7 +6,7 @@ export class Echo extends SystemSubTag {
     constructor(engine: Engine) {
         super(engine, 'echo', {
             category: 'mock',
-            globalName: ['echo', '>']
+            globalName: ['echo', '_']
         });
 
         this.whenArgs(hasCount(0), this.errors.args.notEnough(1))

--- a/test/mocks/subtags/named.ts
+++ b/test/mocks/subtags/named.ts
@@ -1,0 +1,138 @@
+import { SystemSubTag, Engine, hasCount, hasArgs, BBSubTag, Context } from './util';
+import { RawArguments } from '../../../dist/structures/subtag';
+
+export class Named1 extends SystemSubTag {
+    constructor(engine: Engine) {
+        super(engine, 'named1', {
+            category: 'mock'
+        });
+
+        this.setNamedArgs([
+            { key: 'arg1' },
+            { key: 'arg2', optional: true },
+            { key: 'arg3' },
+            { key: 'arg4', repeated: true, optional: true },
+            { key: 'arg5' }
+        ]);
+
+        this.whenArgs(hasArgs(['arg1', 'arg2', 'arg3', 'arg4', 'arg5']), this.fiveArgs)
+            .whenArgs(hasArgs(['arg1', 'arg3', 'arg4', 'arg5']), this.fourArgsOne)
+            .whenArgs(hasArgs(['arg1', 'arg2', 'arg3', 'arg5']), this.fourArgsTwo)
+            .whenArgs(hasArgs(['arg1', 'arg3', 'arg5']), this.threeArgs);
+    }
+
+    async fiveArgs(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'Five ' + JSON.stringify(args);
+    }
+    async fourArgsOne(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'Four1 ' + JSON.stringify(args);
+    }
+    async fourArgsTwo(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'Four2 ' + JSON.stringify(args);
+    }
+    async threeArgs(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'Three ' + JSON.stringify(args);
+    }
+}
+
+export class Named2 extends SystemSubTag {
+    constructor(engine: Engine) {
+        super(engine, 'named2', {
+            category: 'mock'
+        });
+
+        this.setNamedArgs([
+            { key: 'arg1' },
+            { key: 'arg2', optional: true },
+            { key: 'arg3' },
+            { key: 'arg4', repeated: true },
+            { key: 'arg5' }
+        ]);
+
+        this
+            .whenArgs(hasArgs(['arg1', 'arg2', 'arg3', 'arg4', 'arg5']), this.fiveArgs)
+            .whenArgs(hasArgs(['arg1', 'arg3', 'arg4', 'arg5']), this.fourArgsOne)
+            .whenArgs(hasArgs(['arg1', 'arg2', 'arg3', 'arg5']), this.fourArgsTwo)
+            .whenArgs(hasArgs(['arg1', 'arg3', 'arg5']), this.threeArgs);
+    }
+
+    async fiveArgs(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'Five ' + JSON.stringify(args);
+    }
+    async fourArgsOne(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'Four1 ' + JSON.stringify(args);
+    }
+    async fourArgsTwo(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'Four2 ' + JSON.stringify(args);
+    }
+    async threeArgs(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'Three ' + JSON.stringify(args);
+    }
+}
+
+
+export class NamedPriority extends SystemSubTag {
+    constructor(engine: Engine) {
+        super(engine, 'namedp', {
+            category: 'mock'
+        });
+
+        this.setNamedArgs([
+            { key: 'arg1', optional: true },
+            { key: 'arg2', optional: true, priority: true }
+        ]);
+
+        this.whenArgs(hasArgs(['arg1', 'arg2']), this.twoArgs)
+            .whenArgs(hasArgs(['arg2']), this.oneArg);
+    }
+
+    async oneArg(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'One ' + JSON.stringify(args);
+    }
+    async twoArgs(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'Two ' + JSON.stringify(args);
+    }
+}
+
+export class NamedConditional extends SystemSubTag {
+    constructor(engine: Engine) {
+        super(engine, 'namedc', {
+            category: 'mock'
+        });
+
+        this.setNamedArgs([
+            { key: 'arg1', optional: true, conditional: 'arg3' },
+            { key: 'arg2', optional: true, conditional: 'arg1' },
+            { key: 'arg3', optional: true, conditional: 'arg2' },
+            { key: 'arg4', optional: true }
+        ]);
+
+        this.whenArgs(hasArgs(['arg1', 'arg2', 'arg3', 'arg4']), this.fourArgs)
+            .whenArgs(hasArgs(['arg1', 'arg2', 'arg3']), this.threeArgs)
+            .whenArgs(hasArgs(['arg4']), this.oneArg)
+            .default(this.errors.args.notEnough(1));
+    }
+
+    async oneArg(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'One ' + JSON.stringify(args);
+    }
+    async threeArgs(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'Three ' + JSON.stringify(args);
+    }
+    async fourArgs(subtag: BBSubTag, context: Context, rawArgs: RawArguments): Promise<string> {
+        let { args } = await this.parseNamedArgs(subtag, context, rawArgs);
+        return 'Four ' + JSON.stringify(args);
+    }
+}

--- a/test/subtag.test.ts
+++ b/test/subtag.test.ts
@@ -1,12 +1,17 @@
 (async () => {
     let subtags: { [key: string]: { [key: string]: VoidFunction } } = {};
 
+    // Mock subtags
+    subtags.Mock = {};
+    subtags.Mock.Named = await import('./subtag/namedargs.test');
+
     // Basic subtags
     subtags.System = {};
     subtags.System.Comment = await import('./subtag/comment.test');
     subtags.System.Bool = await import('./subtag/bool.test');
     subtags.System.If = await import('./subtag/if.test');
     subtags.System.Switch = await import('./subtag/switch.test');
+    subtags.System.Operator = await import('./subtag/operator.test');
 
     subtags.Math = {};
     subtags.Math.Floor = await import('./subtag/floor.test');

--- a/test/subtag/bool.test.ts
+++ b/test/subtag/bool.test.ts
@@ -3,7 +3,7 @@ import { Bool } from '../../dist/subtags/general/system/bool';
 import { Context, BBSubTag, parse, Engine, SubTag, errors } from '../../dist/index';
 import { MockDb } from '../mocks/mockDatabase';
 import { Echo } from '../mocks/subtags/echo';
-import { checkBackwardsCompat, checkArgRange, contexts } from './util';
+import { checkBackwardsCompat, checkArgRange, contexts, checkLoadOperators } from './util';
 
 export = function test() {
     let engine: Engine = new Engine({ database: new MockDb() });
@@ -15,6 +15,7 @@ export = function test() {
 
     checkBackwardsCompat(subtag, 'bool');
     checkArgRange(context, subtag, 2, 3);
+    checkLoadOperators(e => new Bool(e), Object.keys(Bool.operators));
 
     let tests = [
         {

--- a/test/subtag/comment.test.ts
+++ b/test/subtag/comment.test.ts
@@ -1,6 +1,5 @@
-import { expect } from 'chai';
 import { Comment } from '../../dist/subtags/general/system/comment';
-import { Context, BBSubTag, parse, Engine, SubTag } from '../../dist/index';
+import { Engine, SubTag } from '../../dist/index';
 import { MockDb } from '../mocks/mockDatabase';
 import { Echo } from '../mocks/subtags/echo';
 import { checkBackwardsCompat, contexts, runTest } from './util';
@@ -14,10 +13,6 @@ export = function test() {
     afterEach(() => Echo.values.splice(0, Echo.values.length));
 
     checkBackwardsCompat(subtag, '//');
-
-    it('should not execute inner arguments', async () => {
-
-    });
 
     it('should not return any text', async () => {
         await runTest(context, subtag,

--- a/test/subtag/namedargs.test.ts
+++ b/test/subtag/namedargs.test.ts
@@ -1,0 +1,129 @@
+import { expect } from 'chai';
+import { Named1, Named2, NamedPriority, NamedConditional } from '../mocks/subtags/named';
+import { Context, errors, BBSubTag, parse, Engine, SubTag } from '../../dist';
+import { MockDb } from '../mocks/mockDatabase';
+import { Echo } from '../mocks/subtags/echo';
+import { checkBackwardsCompat, checkArgRange, contexts } from './util';
+import { SubTagError } from '../../dist/structures/subtag';
+
+export = function test() {
+    let engine: Engine = new Engine({ database: new MockDb() });
+    let subtag1 = new Named1(engine);
+    let subtag2 = new Named2(engine);
+    let subtagp = new NamedPriority(engine);
+    let subtagc = new NamedConditional(engine);
+    let context = contexts.basic(engine);
+    engine.register(Echo as typeof SubTag);
+    engine.register(Named1 as typeof SubTag);
+    engine.register(Named2 as typeof SubTag);
+    engine.register(NamedPriority as typeof SubTag);
+    engine.register(NamedConditional as typeof SubTag);
+
+    afterEach(() => Echo.values.splice(0, Echo.values.length));
+
+    async function test(context: Context, cases: { input: string, expected: string | SubTagError, subtag: SubTag<Context>, errors?: number }[]) {
+        for (const test of cases) {
+            let code = parse(test.input).parts[0] as BBSubTag;
+
+            // act
+            let result = await test.subtag.execute(code, context);
+
+            if (!test.errors && context.state.errors.length > 0)
+                for (const err of context.state.errors)
+                    console.error(err);
+            // assert
+            expect(context.state.errors).to.have.length(test.errors === undefined ? 0 : test.errors);
+            expect(result).to.equal(test.expected);
+        }
+    }
+
+    it('should parse named arguments', async () => {
+        // arrange
+        let context = new Context(engine);
+        let cases = [{
+            input: '{named={*arg1;1}{*arg2;2}{*arg3;3}{*arg4;4}{*arg5;5}}',
+            expected: `Five {"arg1":"1","arg2":"2","arg3":"3","arg4":["4"],"arg5":"5"}`,
+            subtag: subtag1
+        }, {
+            input: '{named={*arg1;1}{*arg2;2}{*arg3;3}{*arg4;4}{*arg4;4}{*arg5;5}}',
+            expected: `Five {"arg1":"1","arg2":"2","arg3":"3","arg4":["4","4"],"arg5":"5"}`,
+            subtag: subtag1
+        }, {
+            input: '{named={*arg1;1}{*arg3;3}{*arg4;4}{*arg4;4}{*arg5;5}}',
+            expected: `Four1 {"arg1":"1","arg3":"3","arg4":["4","4"],"arg5":"5"}`,
+            subtag: subtag1
+        }, {
+            input: '{named={*arg1;1}{*arg2;2}{*arg3;3}{*arg5;5}}',
+            expected: `Four2 {"arg1":"1","arg2":"2","arg3":"3","arg5":"5"}`,
+            subtag: subtag1
+        }, {
+            input: '{named={*arg1;1}{*arg3;3}{*arg5;5}}',
+            expected: `Three {"arg1":"1","arg3":"3","arg5":"5"}`,
+            subtag: subtag1
+        }];
+        await test(context, cases);
+    });
+    it('should parse positional arguments as named arguments', async () => {
+        // arrange
+        let context = new Context(engine);
+        let cases = [{
+            input: '{named;1;2;3;4;5}',
+            expected: `Five {"arg1":"1","arg2":"2","arg3":"3","arg4":["4"],"arg5":"5"}`,
+            subtag: subtag1
+        }, {
+            input: '{named;1;2;3;4;4;5}',
+            expected: `Five {"arg1":"1","arg2":"2","arg3":"3","arg4":["4","4"],"arg5":"5"}`,
+            subtag: subtag1
+        }, {
+            input: '{named;1;2;3;5}',
+            expected: `Four2 {"arg1":"1","arg2":"2","arg3":"3","arg5":"5"}`,
+            subtag: subtag1
+        }, {
+            input: '{named;1;3;5}',
+            expected: `Three {"arg1":"1","arg3":"3","arg5":"5"}`,
+            subtag: subtag1
+        }, {
+            input: '{named;1;3;4;5}',
+            expected: `Four1 {"arg1":"1","arg3":"3","arg4":["4"],"arg5":"5"}`,
+            subtag: subtag2
+        }];
+        await test(context, cases);
+    });
+    it('should parse positional arguments with priority', async () => {
+        // arrange
+        let context = new Context(engine);
+        let cases = [{
+            input: '{named;1;2}',
+            expected: `Two {"arg1":"1","arg2":"2"}`,
+            subtag: subtagp
+        }, {
+            input: '{named;2}',
+            expected: `One {"arg2":"2"}`,
+            subtag: subtagp
+        }];
+        await test(context, cases);
+    });
+    it('should parse positional arguments with conditions', async () => {
+        // arrange
+        let context = new Context(engine);
+        let cases = [{
+            input: '{named;1;2;3;4}',
+            expected: `Four {"arg1":"1","arg2":"2","arg3":"3","arg4":"4"}`,
+            subtag: subtagc
+        }, {
+            input: '{named;4}',
+            expected: `One {"arg4":"4"}`,
+            subtag: subtagc
+        }, {
+            input: '{named;1;2;3}',
+            expected: `Three {"arg1":"1","arg2":"2","arg3":"3"}`,
+            subtag: subtagc
+        }, {
+            input: '{named;1;2}',
+            expected: '`[1:1][BB-A-TM] Too many arguments. Maximum 4`',
+            subtag: subtagc,
+            errors: 1
+        }];
+        await test(context, cases);
+    });
+};

--- a/test/subtag/operator.test.ts
+++ b/test/subtag/operator.test.ts
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import { Operator } from '../../dist/subtags/general/system/operator';
+import { Context, BBSubTag, parse, Engine, SubTag } from '../../dist/index';
+import { MockDb } from '../mocks/mockDatabase';
+import { Echo } from '../mocks/subtags/echo';
+import { checkBackwardsCompat, contexts, runTest } from './util';
+
+export = function test() {
+    let engine: Engine = new Engine({ database: new MockDb() });
+    let subtag = new Operator(engine);
+    let context = contexts.basic(engine);
+    engine.register(Echo as typeof SubTag);
+
+    afterEach(() => Echo.values.splice(0, Echo.values.length));
+
+    it('should initially have no operators', () => {
+        // assert
+        expect(subtag.globalNames).to.have.length(0);
+    });
+
+    it('should not allow a direct call', async () => {
+        await runTest(context, subtag,
+            {
+                input: [],
+                expected: SubTag.errors.value.notAnOperator('system.operator'),
+                echo: [],
+                errors: 1
+            });
+    })
+}

--- a/test/subtag/switch.test.ts
+++ b/test/subtag/switch.test.ts
@@ -79,8 +79,6 @@ export = function test() {
             })
     });
 
-
-
     it('should always pick the first match', async () => {
         await runTest(context, subtag,
             {

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,23 @@
+{
+    "defaultSeverity": "error",
+    "extends": [],
+    "jsRules": {},
+    "rules": {
+        "strict": 0,
+        "semicolon": true,
+        "indent": [
+            true,
+            "spaces",
+            4
+        ],
+        "quotemark": [
+            true,
+            "single"
+        ],
+        "no-undef": 1,
+        "no-global-assign": 1,
+        "comma-dangle": "warn",
+        "no-trailing-spaces": "warn"
+    },
+    "rulesDirectory": []
+}


### PR DESCRIPTION
* Whitespace cleanup

* Add {System.Operator} (WIP)

* Fix failing {System.Operator} test

* named args work

* fixed parsing logic and rewrote subtags

* remove console.log

* tslint

* more tslint

* revert breaking change

* rewrite to arrow func

* tests and some fixes

* fix some type casting, make rawArgs required

* make rawArgs not optional on SubTagHandler

* Optimisations

Ive moved some of the computing of the named arguments data to the `SubTag#setNamedArgs` method as they will not change from execution to execution.

These properties are the max & min lengths, as well as the number of important & required arguments after a given position.

Also added som logical optimisations, as well as reducing the amount of code done for some checks to make it more readable

* tiny syntatic update

* Remove redundant checks